### PR TITLE
[#55]feat: XMLHttpRequest와 Promise를 활용하여 API 가져오는 객체 생성

### DIFF
--- a/src/lib/API.js
+++ b/src/lib/API.js
@@ -1,0 +1,40 @@
+class API {
+  constructor(url) {
+    this.url = url;
+    this.request = new XMLHttpRequest();
+  }
+
+  open(method, data) {
+    return new Promise((resolve, reject) => {
+      this.request.open(method, this.url);
+      this.request.onload = () => {
+        this.onload(resolve, reject);
+      };
+
+      if (data) {
+        this.request.setRequestHeader('content-type', 'application/json');
+        this.request.send(JSON.stringify(data));
+      } else {
+        this.request.send();
+      }
+    });
+  }
+
+  onload(resolve, reject) {
+    if (this.request.status === 200 || this.request.status === 201) {
+      resolve(this.request.responseText);
+    } else {
+      reject(Error('응답 실패'));
+    }
+  }
+
+  get() {
+    return this.open('GET');
+  }
+
+  post(data) {
+    return this.open('POST', data);
+  }
+}
+
+module.exports = API;


### PR DESCRIPTION
> close #55 

# 내용
XMLHttpRequest와 Promise를 활용하여 API 가져오는 객체 생성

# 구현 중 이슈
- open, onload를 구분해서 재활용 하여 각각의 용도별 메소드를 만들다가 요청을 못받아 오는 현상 발생

# 해결
- request에 대한 onload에 대해 메소드를 실행하여 resolve, reject를 넘겨주어 처리하였음